### PR TITLE
Basic support for float32

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -455,7 +455,7 @@ namespace libDotNetClr
                 {
                     stack.Add(MethodArgStack.Int64((long)item.Operand));
                 }
-                //push float64
+                //push float32
                 else if (item.OpCodeName == "ldc.r4")
                 {
                     //Puts an float32 with value onto the arg stack
@@ -484,6 +484,11 @@ namespace libDotNetClr
                     if (numb.type == StackItemType.Int32)
                     {
                         //We don't need to do anything because it's already int32
+                    }
+                    else if (numb.type == StackItemType.Float32)
+                    {
+                        stack.RemoveAt(stack.Count - 1);
+                        stack.Add(MethodArgStack.Int32((int)(float)numb.value));
                     }
                     else
                     {

--- a/LibDotNetParser/CILApi/IL/IlDecompiler.cs
+++ b/LibDotNetParser/CILApi/IL/IlDecompiler.cs
@@ -742,7 +742,18 @@ namespace LibDotNetParser.CILApi
                 case OpCodeOperandType.InlineSwitch:
                     throw new NotImplementedException();
                 case OpCodeOperandType.ShortInlineR:
-                    throw new NotImplementedException();
+                    {
+                        byte fi = code[Offset + 1];
+                        byte s2 = code[Offset + 2];
+                        byte t = code[Offset + 3];
+                        byte f = code[Offset + 4];
+                        byte[] num2 = new byte[] { fi, s2, t, f };
+                        var numb2 = BitConverter.ToSingle(num2, 0);
+
+                        ret.Size += 4;
+                        ret.Operand = numb2;
+                        return ret;
+                    }
                 case OpCodeOperandType.InlineType:
                     {
                         byte fi = code[Offset + 1];

--- a/LibDotNetParser/CILApi/MethodArgStack.cs
+++ b/LibDotNetParser/CILApi/MethodArgStack.cs
@@ -106,7 +106,7 @@ namespace LibDotNetParser
         }
         public static MethodArgStack Float32(float value)
         {
-            return new MethodArgStack() { type = StackItemType.String, value = value };
+            return new MethodArgStack() { type = StackItemType.Float32, value = value };
         }
         public static MethodArgStack Float64(float value)
         {

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -480,6 +480,17 @@ namespace DotNetparserTester
             {
                 TestFail("String.IndexOf() is not 1");
             }
+
+            float temp = 5;
+            if ((int)temp == 5)
+            {
+                TestSuccess("float was 5");
+            }
+            else
+            {
+                TestFail("float equality failed");
+            }
+
             TestsComplete();
         }
         private static void TestByRef(string t, ref int a)


### PR DESCRIPTION
## General Notes

I tried loading the sample project and quickly found that floats were not supported.  It looked like the support was almost there, so I added a bit of code to support loading in floats and comparing them against integers.

Note: Most floating point code will not work as the existing code assumes 32 bit integers and their ilk in almost all cases.

## Fix/Implementation 

1. Added support for `OpCodeOperandType.ShortInlineR`, which allows loading a float.
2. Added support for converting from float32 to int32 so that we can run a simple test.
3. Fixed a typo that incorrectly set the type of a float32 to a string on creation.

## Testing

Added a test case to the TestApp project which will load a value into a float and compare it against an integer after casting back to an integer.  The test passes!