### PR TITLE
Add Pop/Peek methods to the CustomList

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -592,14 +592,11 @@ namespace libDotNetClr
                 {
                     if (stack.Count < 2)
                         throw new Exception("There has to be 2 or more items on the stack for ceq instruction to work!");
-                    var numb1 = stack[stack.Count - 2].value;
-                    var numb2 = stack[stack.Count - 1].value;
-                    int Numb1;
-                    int Numb2;
+                    var numb1 = stack.Pop().value;
+                    var numb2 = stack.Pop().value;
 
                     if (numb1 is float)
                     {
-                        stack.RemoveRange(stack.Count - 2, 2);
                         if ((float)numb1 == (float)numb2)
                         {
                             stack.Add(MethodArgStack.Int32(1));
@@ -611,6 +608,9 @@ namespace libDotNetClr
                     }
                     else
                     {
+                        int Numb1;
+                        int Numb2;
+
                         if (numb1 is int)
                         {
                             Numb1 = (int)numb1;
@@ -647,7 +647,6 @@ namespace libDotNetClr
                             return null;
                         }
 
-                        stack.RemoveRange(stack.Count - 2, 2);
                         if (Numb1 == Numb2)
                         {
                             //push 1

--- a/DotNetClr/CustomList.cs
+++ b/DotNetClr/CustomList.cs
@@ -71,5 +71,22 @@ namespace libDotNetClr
 
         }
         public T Current { get { return backend.GetEnumerator().Current; } }
+
+        // since this data structure is being used as the type stack it is helpful to include some stack-like methods
+        public T Pop()
+        {
+            if (Count == 0) throw new InvalidOperationException("Stack empty.");
+
+            var item = backend[Count - 1];
+            backend.RemoveAt(Count - 1);
+            return item;
+        }
+
+        public T Peek()
+        {
+            if (Count == 0) throw new InvalidOperationException("Stack empty.");
+
+            return backend[Count - 1];
+        }
     }
 }


### PR DESCRIPTION
## General Notes

I noticed that the project uses a `CustomList` instead of a `Stack` for the .NET type stack.  This resulted in first accessing the item and then removing it via a `RemoveAt` or `RemoveRange` call.  This PR adds stack-like methods to `CustomList` and includes an example of how a method could be refactored to use it.

This is more meant to showcase how this could look.  If this looks like a nice path forward then I can refactor the entire DotNetClr.cs file.  Let me know what you think!

## Testing

Lightly tested by modifying the `ceq` opcode to use the new `Pop` method.

## TODO

Refactor the rest of DotNetClr.cs if this approach is liked.