### PR TITLE
Fix 'reference' typo

### DIFF
--- a/DotNetClr/CLR/CLRInternalMethodsImpl.cs
+++ b/DotNetClr/CLR/CLRInternalMethodsImpl.cs
@@ -34,7 +34,7 @@ namespace libDotNetClr
             RegisterCustomInternalMethod("strLen", Internal__System_String_Get_Length);
             RegisterCustomInternalMethod("String_get_Chars_1", Internal__System_String_get_Chars_1);
             RegisterCustomInternalMethod("GetObjType", GetObjType);
-            RegisterCustomInternalMethod("Type_FromRefernce", GetTypeFromRefrence);
+            RegisterCustomInternalMethod("Type_FromRefernce", GetTypeFromReference);
             RegisterCustomInternalMethod("GetAssemblyFromType", GetAssemblyFromType);
             RegisterCustomInternalMethod("InternalAddItemToList", ListAddItem);
             RegisterCustomInternalMethod("String_ToUpper", String_ToUpper);
@@ -334,7 +334,7 @@ namespace libDotNetClr
 
             returnValue = assembly;
         }
-        private void GetTypeFromRefrence(MethodArgStack[] Stack, ref MethodArgStack returnValue, DotNetMethod method)
+        private void GetTypeFromReference(MethodArgStack[] Stack, ref MethodArgStack returnValue, DotNetMethod method)
         {
             var re = Stack[Stack.Length - 1];
             if (re.type != StackItemType.Object) throw new InvalidOperationException();

--- a/DotNetClr/CLR/CLRInternalMethodsImpl.cs
+++ b/DotNetClr/CLR/CLRInternalMethodsImpl.cs
@@ -34,7 +34,7 @@ namespace libDotNetClr
             RegisterCustomInternalMethod("strLen", Internal__System_String_Get_Length);
             RegisterCustomInternalMethod("String_get_Chars_1", Internal__System_String_get_Chars_1);
             RegisterCustomInternalMethod("GetObjType", GetObjType);
-            RegisterCustomInternalMethod("Type_FromRefernce", GetTypeFromReference);
+            RegisterCustomInternalMethod("Type_FromReference", GetTypeFromReference);
             RegisterCustomInternalMethod("GetAssemblyFromType", GetAssemblyFromType);
             RegisterCustomInternalMethod("InternalAddItemToList", ListAddItem);
             RegisterCustomInternalMethod("String_ToUpper", String_ToUpper);

--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -302,7 +302,7 @@ namespace libDotNetClr
             var decompiler = new IlDecompiler(m);
             foreach (var item in dlls)
             {
-                decompiler.AddRefernce(item.Value);
+                decompiler.AddReference(item.Value);
             }
             var code = decompiler.Decompile();
             int i;

--- a/LibDotNetParser/CILApi/IL/IlDecompiler.cs
+++ b/LibDotNetParser/CILApi/IL/IlDecompiler.cs
@@ -21,9 +21,9 @@ namespace LibDotNetParser.CILApi
             m = method;
             mainFile = m.File;
             code = m.GetBody();
-            AddRefernce(m.Parrent.File);
+            AddReference(m.Parrent.File);
         }
-        public void AddRefernce(DotNetFile f)
+        public void AddReference(DotNetFile f)
         {
             ContextTypes.Add(f);
         }
@@ -428,7 +428,7 @@ namespace LibDotNetParser.CILApi
                                 }
                                 else
                                 {
-                                    // Console.WriteLine($"[ILDecompiler: WARN] Cannot resolve method RVA. Are you missing a call to AddRefernce()??. Method data: {anamespace}.{typeName}.{funcName}");
+                                    // Console.WriteLine($"[ILDecompiler: WARN] Cannot resolve method RVA. Are you missing a call to AddReference()??. Method data: {anamespace}.{typeName}.{funcName}");
                                 }
                             }
 
@@ -674,7 +674,7 @@ namespace LibDotNetParser.CILApi
                                     }
                                     else
                                     {
-                                        Console.WriteLine($"[ILDecompiler: WARN] Cannot resolve method RVA. Are you missing a call to AddRefernce()??. Method data: {anamespace}.{typeName}.{funcName}");
+                                        Console.WriteLine($"[ILDecompiler: WARN] Cannot resolve method RVA. Are you missing a call to AddReference()??. Method data: {anamespace}.{typeName}.{funcName}");
                                     }
                                 }
 

--- a/LibDotNetParser/CILApi/MethodArgStack.cs
+++ b/LibDotNetParser/CILApi/MethodArgStack.cs
@@ -80,7 +80,7 @@ namespace LibDotNetParser
                 case StackItemType.Array:
                     return "Array";
                 case StackItemType.ObjectRef:
-                    return "Object refrence to " + ObjectType.FullName;
+                    return "Object reference to " + ObjectType.FullName;
                 case StackItemType.MethodPtr:
                     return "Method Pointer to " + ((DotNetMethod)value).ToString();
                 default:

--- a/mscorlib/Reflection/Type.cs
+++ b/mscorlib/Reflection/Type.cs
@@ -35,11 +35,11 @@ namespace System
         }
         public static Type GetTypeFromHandle(RuntimeTypeHandle handle)
         {
-            return Type_FromRefernce(handle);
+            return Type_FromReference(handle);
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public extern static Type Type_FromRefernce(RuntimeTypeHandle handle);
+        public extern static Type Type_FromReference(RuntimeTypeHandle handle);
         [MethodImpl(MethodImplOptions.InternalCall)]
         public extern static Assembly GetAssemblyFromType(Type t);
         [MethodImpl(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
## General Notes

This PR fixes a typo I noticed while looking at the code.  I checked for all instances of "refrence" and "refernce" and changed it to "reference".