### PR TITLE
Add support for rem, and, or, xor and not opcodes.

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -676,6 +676,98 @@ namespace libDotNetClr
                         stack.Add(MethodArgStack.Int32(result));
                     }
                 }
+                else if (item.OpCodeName == "rem")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 && a.type != StackItemType.Float32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 1)", "Internal CLR error");
+                        return null;
+                    }
+                    if (b.type != StackItemType.Int32 && b.type != StackItemType.Float32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 2)", "Internal CLR error");
+                        return null;
+                    }
+                    if (a.type == StackItemType.Float32)
+                    {
+                        var numb1 = (float)a.value;
+                        var numb2 = (float)b.value;
+                        var result = numb2 % numb1;
+                        stack.Add(MethodArgStack.Float32(result));
+                    }
+                    else
+                    {
+                        var numb1 = (int)a.value;
+                        var numb2 = (int)b.value;
+                        var result = numb2 % numb1;
+                        stack.Add(MethodArgStack.Int32(result));
+                    }
+                }
+                else if (item.OpCodeName == "and")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 || b.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var numb2 = (int)b.value;
+                    var result = numb1 & numb2;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
+                else if (item.OpCodeName == "or")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 || b.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var numb2 = (int)b.value;
+                    var result = numb1 | numb2;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
+                else if (item.OpCodeName == "xor")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 || b.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var numb2 = (int)b.value;
+                    var result = numb1 ^ numb2;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
+                else if (item.OpCodeName == "not")
+                {
+                    var a = stack.Pop();
+
+                    if (a.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var result = ~numb1;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
                 else if (item.OpCodeName == "ceq")
                 {
                     if (stack.Count < 2)
@@ -1557,7 +1649,7 @@ namespace libDotNetClr
                     }
                     if (t2 == null)
                     {
-                        clrError("Failed to resolve token. OpCode: ldtoken. Type: "+index.Namespace+"."+index.Name, "Internal CLR error");
+                        clrError("Failed to resolve token. OpCode: ldtoken. Type: " + index.Namespace + "." + index.Name, "Internal CLR error");
                         return null;
                     }
 

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -563,8 +563,29 @@ namespace DotNetparserTester
             {
                 TestFail("float was not correctly converted from an int");
             }
+            i = 7;
+            TestAssert((i % 3) == 1, "int32 modulus");
+            fl = 2.5f;
+            TestAssert((fl % 1f) == 0.5f, "float32 modulus");
+            i = 0x12345678;
+            i2 = 0x00ff00ff;
+            TestAssert((i & i2) == 0x00340078, "int32 bitwise and");
+            i = 0x12345678;
+            i2 = 0x0f0f0f0f;
+            TestAssert((i | i2) == 0x1f3f5f7f, "int32 bitwise or");
+            i = 0x12345678;
+            i2 = 0x0a0a0a0a;
+            TestAssert((i ^ i2) == 0x183E5C72, "int32 bitwise xor");
+            uint ui = 0x12345678;
+            TestAssert(~ui == 0xEDCBA987, "uint32 bitwise not");
 
             TestsComplete();
+        }
+
+        private static void TestAssert(bool test, string info)
+        {
+            if (test) TestSuccess($"{info} works correctly");
+            else TestFail($"{info} works incorrectly");
         }
 
         private static string GetTestMessage2(string arg)


### PR DESCRIPTION
## General Notes

This PR adds the rem, and, or, xor and not opcodes to DotNetClr.

It looks like the PR picked up a minor reformat as well (automatic from Visual Studio).  I can strip this change out if you would like.

## Testing

Wrote tests for each of the new opcodes, include both an `int32` and `float32` version for `rem`