### PR TITLE
Add support for (signed) shift operations on int32 type values

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -754,6 +754,38 @@ namespace libDotNetClr
                     var result = numb1 ^ numb2;
                     stack.Add(MethodArgStack.Int32(result));
                 }
+                else if (item.OpCodeName == "shl")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 || b.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var numb2 = (int)b.value;
+                    var result = numb2 << numb1;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
+                else if (item.OpCodeName == "shr")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 || b.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var numb2 = (int)b.value;
+                    var result = numb2 >> numb1;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
                 else if (item.OpCodeName == "not")
                 {
                     var a = stack.Pop();

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -578,6 +578,10 @@ namespace DotNetparserTester
             TestAssert((i ^ i2) == 0x183E5C72, "int32 bitwise xor");
             uint ui = 0x12345678;
             TestAssert(~ui == 0xEDCBA987, "uint32 bitwise not");
+            i = 0x12345678;
+            TestAssert((i >> 4) == 0x01234567, "int32 shift right");
+            i = 0x12345678;
+            TestAssert((i << 4) == 0x23456780, "int32 shift left");
 
             TestsComplete();
         }


### PR DESCRIPTION
## General Notes

This PR adds support for both the `shl` and `shr` opcodes for int32.

## Testing

Added a test method for each of shift left and shift right.