### PR TITLE
Move math operations into their own static class

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -557,154 +557,38 @@ namespace libDotNetClr
                 #region Math
                 else if (item.OpCodeName == "add")
                 {
-                    var a = stack[stack.Count - 2];
-                    var b = stack[stack.Count - 1];
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (a.type != StackItemType.Int32 && a.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 1)", "Internal CLR error");
-                        return null;
-                    }
-                    if (b.type != StackItemType.Int32 && b.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 2)", "Internal CLR error");
-                        return null;
-                    }
-                    if (a.type == StackItemType.Float32)
-                    {
-                        var numb1 = (float)a.value;
-                        var numb2 = (float)b.value;
-                        var result = numb1 + numb2;
-                        stack.Add(MethodArgStack.Float32(result));
-                    }
-                    else
-                    {
-                        var numb1 = (int)a.value;
-                        var numb2 = (int)b.value;
-                        var result = numb1 + numb2;
-                        stack.Add(MethodArgStack.Int32(result));
-                    }
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.Add));
                 }
                 else if (item.OpCodeName == "sub")
                 {
-                    var a = stack[stack.Count - 2];
-                    var b = stack[stack.Count - 1];
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (a.type != StackItemType.Int32 && a.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 1)", "Internal CLR error");
-                        return null;
-                    }
-                    if (b.type != StackItemType.Int32 && b.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 2)", "Internal CLR error");
-                        return null;
-                    }
-                    if (a.type == StackItemType.Float32)
-                    {
-                        var numb1 = (float)a.value;
-                        var numb2 = (float)b.value;
-                        var result = numb1 - numb2;
-                        stack.Add(MethodArgStack.Float32(result));
-                    }
-                    else
-                    {
-                        var numb1 = (int)a.value;
-                        var numb2 = (int)b.value;
-                        var result = numb1 - numb2;
-                        stack.Add(MethodArgStack.Int32(result));
-                    }
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.Subtract));
                 }
                 else if (item.OpCodeName == "div")
                 {
-                    var a = stack[stack.Count - 2];
-                    var b = stack[stack.Count - 1];
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    //TODO: Check if dividing by zero
-                    if (a.type != StackItemType.Int32 && a.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 1)", "Internal CLR error");
-                        return null;
-                    }
-                    if (b.type != StackItemType.Int32 && b.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 2)", "Internal CLR error");
-                        return null;
-                    }
-                    if (a.type == StackItemType.Float32)
-                    {
-                        var numb1 = (float)a.value;
-                        var numb2 = (float)b.value;
-                        var result = numb1 / numb2;
-                        stack.Add(MethodArgStack.Float32(result));
-                    }
-                    else
-                    {
-                        var numb1 = (int)a.value;
-                        var numb2 = (int)b.value;
-                        var result = numb1 / numb2;
-                        stack.Add(MethodArgStack.Int32(result));
-                    }
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.Divide));
                 }
                 else if (item.OpCodeName == "mul")
                 {
-                    var a = stack[stack.Count - 2];
-                    var b = stack[stack.Count - 1];
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (a.type != StackItemType.Int32 && a.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 1)", "Internal CLR error");
-                        return null;
-                    }
-                    if (b.type != StackItemType.Int32 && b.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 2)", "Internal CLR error");
-                        return null;
-                    }
-                    if (a.type == StackItemType.Float32)
-                    {
-                        var numb1 = (float)a.value;
-                        var numb2 = (float)b.value;
-                        var result = numb1 * numb2;
-                        stack.Add(MethodArgStack.Float32(result));
-                    }
-                    else
-                    {
-                        var numb1 = (int)a.value;
-                        var numb2 = (int)b.value;
-                        var result = numb1 * numb2;
-                        stack.Add(MethodArgStack.Int32(result));
-                    }
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.Multiply));
                 }
                 else if (item.OpCodeName == "rem")
                 {
                     var a = stack.Pop();
                     var b = stack.Pop();
 
-                    if (a.type != StackItemType.Int32 && a.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 1)", "Internal CLR error");
-                        return null;
-                    }
-                    if (b.type != StackItemType.Int32 && b.type != StackItemType.Float32)
-                    {
-                        clrError($"Error in {item.OpCodeName} opcode: type is not int32 or float (operand 2)", "Internal CLR error");
-                        return null;
-                    }
-                    if (a.type == StackItemType.Float32)
-                    {
-                        var numb1 = (float)a.value;
-                        var numb2 = (float)b.value;
-                        var result = numb2 % numb1;
-                        stack.Add(MethodArgStack.Float32(result));
-                    }
-                    else
-                    {
-                        var numb1 = (int)a.value;
-                        var numb2 = (int)b.value;
-                        var result = numb2 % numb1;
-                        stack.Add(MethodArgStack.Int32(result));
-                    }
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.Remainder));
                 }
                 else if (item.OpCodeName == "and")
                 {

--- a/DotNetClr/CLR/MathOperations.cs
+++ b/DotNetClr/CLR/MathOperations.cs
@@ -1,0 +1,117 @@
+﻿using LibDotNetParser;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace libDotNetClr
+{
+    public static class MathOperations
+    {
+        public enum Operation
+        {
+            Add,
+            Subtract,
+            Multiply,
+            Divide,
+            Remainder,
+            Equality
+        }
+
+        public static MethodArgStack Op(MethodArgStack arg1, MethodArgStack arg2, Operation op)
+        {
+            if (arg1.type != arg2.type) throw new Exception("Inconsistent type definitions");
+
+            switch (arg1.type)
+            {
+                case StackItemType.Float32: return OpWithFloat32(arg1, arg2, op);
+                case StackItemType.Float64: return OpWithFloat64(arg1, arg2, op);
+                case StackItemType.Int32: return OpWithInt32(arg1, arg2, op);
+                case StackItemType.Int64: return OpWithInt64(arg1, arg2, op);
+                case StackItemType.ldnull: return OpWithLdNull(arg1, arg2, op);
+                default: throw new NotImplementedException();
+            }
+        }
+
+        public static MethodArgStack OpWithFloat32(MethodArgStack arg1, MethodArgStack arg2, Operation op)
+        {
+            float v1 = (float)arg1.value;
+            float v2 = (float)arg2.value;
+
+            switch (op)
+            {
+                case Operation.Add: return MethodArgStack.Float32(v1 + v2);
+                case Operation.Subtract: return MethodArgStack.Float32(v1 - v2);
+                case Operation.Multiply: return MethodArgStack.Float32(v1 * v2);
+                case Operation.Divide: return MethodArgStack.Float32(v1 / v2);
+                case Operation.Remainder: return MethodArgStack.Float32(v1 % v2);
+                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                default: throw new Exception("Invalid operation");
+            }
+        }
+
+        public static MethodArgStack OpWithFloat64(MethodArgStack arg1, MethodArgStack arg2, Operation op)
+        {
+            double v1 = (double)arg1.value;
+            double v2 = (double)arg2.value;
+
+            switch (op)
+            {
+                case Operation.Add: return MethodArgStack.Float64(v1 + v2);
+                case Operation.Subtract: return MethodArgStack.Float64(v1 - v2);
+                case Operation.Multiply: return MethodArgStack.Float64(v1 * v2);
+                case Operation.Divide: return MethodArgStack.Float64(v1 / v2);
+                case Operation.Remainder: return MethodArgStack.Float64(v1 % v2);
+                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                default: throw new Exception("Invalid operation");
+            }
+        }
+
+        public static MethodArgStack OpWithInt32(MethodArgStack arg1, MethodArgStack arg2, Operation op)
+        {
+            int v1 = (int)arg1.value;
+            int v2 = (int)arg2.value;
+
+            switch (op)
+            {
+                case Operation.Add: return MethodArgStack.Int32(v1 + v2);
+                case Operation.Subtract: return MethodArgStack.Int32(v1 - v2);
+                case Operation.Multiply: return MethodArgStack.Int32(v1 * v2);
+                case Operation.Divide: return MethodArgStack.Int32(v1 / v2);
+                case Operation.Remainder: return MethodArgStack.Int32(v1 % v2);
+                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                default: throw new Exception("Invalid operation");
+            }
+        }
+
+        public static MethodArgStack OpWithInt64(MethodArgStack arg1, MethodArgStack arg2, Operation op)
+        {
+            long v1 = (long)arg1.value;
+            long v2 = (long)arg2.value;
+
+            switch (op)
+            {
+                case Operation.Add: return MethodArgStack.Int64(v1 + v2);
+                case Operation.Subtract: return MethodArgStack.Int64(v1 - v2);
+                case Operation.Multiply: return MethodArgStack.Int64(v1 * v2);
+                case Operation.Divide: return MethodArgStack.Int64(v1 / v2);
+                case Operation.Remainder: return MethodArgStack.Int64(v1 % v2);
+                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                default: throw new Exception("Invalid operation");
+            }
+        }
+
+        public static MethodArgStack OpWithLdNull(MethodArgStack arg1, MethodArgStack arg2, Operation op)
+        {
+            object v1 = arg1.value;
+            object v2 = arg2.value;
+
+            switch (op)
+            {
+                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                default: throw new Exception("Invalid operation");
+            }
+        }
+    }
+}

--- a/LibDotNetParser/CILApi/MethodArgStack.cs
+++ b/LibDotNetParser/CILApi/MethodArgStack.cs
@@ -108,7 +108,7 @@ namespace LibDotNetParser
         {
             return new MethodArgStack() { type = StackItemType.Float32, value = value };
         }
-        public static MethodArgStack Float64(float value)
+        public static MethodArgStack Float64(double value)
         {
             return new MethodArgStack() { type = StackItemType.Float64, value = value };
         }


### PR DESCRIPTION
## General Notes

I noticed that there was a lot of code duplication, and would be even more as more types had their math operations implemented.  I thought it might be interesting to pull these operations out into a static class or something similar.

I'm curious on your thoughts @MishaTY - if you don't mind this approach then I have a follow up PR that adds decent support for doubles and longs, as well as converts the `ceq` instruction over to use this new `MathOperations` static class.

## Testing

Reran tests and everything works as expected.