### PR TITLE
Add more .NET types

### DIFF
--- a/DotNetClr/CLR/CLRInternalMethodsImpl.cs
+++ b/DotNetClr/CLR/CLRInternalMethodsImpl.cs
@@ -462,7 +462,7 @@ namespace libDotNetClr
             var str = (string)Stack[0].value;
             var index = (int)Stack[1].value;
 
-            returnValue = new MethodArgStack() { type = StackItemType.String, value = str[index] };
+            returnValue = new MethodArgStack() { type = StackItemType.Char, value = str[index] };
         }
 
         private void Internal__System_String_Get_Length(MethodArgStack[] Stack, ref MethodArgStack returnValue, DotNetMethod method)

--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -684,64 +684,7 @@ namespace libDotNetClr
                     var a = stack.Pop();
                     var b = stack.Pop();
 
-                    if (a.type == b.type && a.type != StackItemType.Int32)
-                    {
-                        stack.Add(MathOperations.Op(a, b, MathOperations.Operation.Equality));
-                    }
-                    else
-                    {
-                        var numb1 = a.value;
-                        var numb2 = b.value;
-                        int Numb1;
-                        int Numb2;
-
-                        if (numb1 is int)
-                        {
-                            Numb1 = (int)numb1;
-                        }
-                        else if (numb1 is char)
-                        {
-                            Numb1 = (int)(char)numb1;
-                        }
-                        else if (numb1 is null)
-                        {
-                            Numb1 = 0;
-                        }
-                        else
-                        {
-                            clrError("Do not know where to branch, as the stack is corrupt", "Internal CLR error");
-                            return null;
-                        }
-
-                        if (numb2 is int)
-                        {
-                            Numb2 = (int)numb2;
-                        }
-                        else if (numb2 is char)
-                        {
-                            Numb2 = (int)(char)numb2;
-                        }
-                        else if (numb2 is null)
-                        {
-                            Numb2 = 0;
-                        }
-                        else
-                        {
-                            clrError("Do not know where to branch, as the stack is corrupt", "Internal CLR error");
-                            return null;
-                        }
-
-                        if (Numb1 == Numb2)
-                        {
-                            //push 1
-                            stack.Add(MethodArgStack.Int32(1));
-                        }
-                        else
-                        {
-                            //push 0
-                            stack.Add(MethodArgStack.Int32(0));
-                        }
-                    }
+                    stack.Add(MathOperations.Op(a, b, MathOperations.Operation.Equality));
                 }
                 else if (item.OpCodeName == "cgt")
                 {

--- a/DotNetClr/CLR/MathOperations.cs
+++ b/DotNetClr/CLR/MathOperations.cs
@@ -19,8 +19,25 @@ namespace libDotNetClr
             Equality
         }
 
+        private static MethodArgStack ConvertToInt32(MethodArgStack arg)
+        {
+            switch (arg.type)
+            {
+                case StackItemType.Int32: return arg;
+                case StackItemType.Char: return MethodArgStack.Int32((int)(char)arg.value);
+                default: throw new Exception("Unsupported type conversion");
+            }
+        }
+
         public static MethodArgStack Op(MethodArgStack arg1, MethodArgStack arg2, Operation op)
         {
+            if (arg1.type == StackItemType.Int32 || arg2.type == StackItemType.Int32)
+            {
+                // int32 is a special case where types such as 'char' and 'boolean' can be converted to an int32 implicitely
+                arg1 = ConvertToInt32(arg1);
+                arg2 = ConvertToInt32(arg2);
+            }
+
             if (arg1.type != arg2.type) throw new Exception("Inconsistent type definitions");
 
             switch (arg1.type)

--- a/LibDotNetParser/CILApi/DotNetMethod.cs
+++ b/LibDotNetParser/CILApi/DotNetMethod.cs
@@ -218,37 +218,37 @@ namespace LibDotNetParser.CILApi
                 case 0x02:
                     {
                         sig = "bool";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.Boolean;
                         break;
                     }
                 case 0x03:
                     {
                         sig = "char";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.Char;
                         break;
                     }
                 case 0x04:
                     {
                         sig = "sbyte";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.SByte;
                         break;
                     }
                 case 0x05:
                     {
                         sig = "byte";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.Byte;
                         break;
                     }
                 case 0x06:
                     {
                         sig = "short";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.Int16;
                         break;
                     }
                 case 0x07:
                     {
                         sig = "ushort";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.UInt16;
                         break;
                     }
                 case 0x08:
@@ -260,7 +260,7 @@ namespace LibDotNetParser.CILApi
                 case 0x09:
                     {
                         sig = "uint";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.UInt32;
                         break;
                     }
                 case 0x0A:
@@ -272,7 +272,7 @@ namespace LibDotNetParser.CILApi
                 case 0x0B:
                     {
                         sig = "ulong";
-                        ret.type = StackItemType.Int64;
+                        ret.type = StackItemType.UInt64;
                         break;
                     }
                 case 0x0C:
@@ -473,14 +473,14 @@ namespace LibDotNetParser.CILApi
                     {
                         //IntPtr
                         sig = "IntPtr";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.IntPtr;
                         break;
                     }
                 case 0x19:
                     {
                         //UIntPtr
                         sig = "UIntPtr";
-                        ret.type = StackItemType.Int32;
+                        ret.type = StackItemType.UIntPtr;
                         break;
                     }
                 case 0x1B:

--- a/LibDotNetParser/CILApi/MethodArgStack.cs
+++ b/LibDotNetParser/CILApi/MethodArgStack.cs
@@ -149,17 +149,26 @@ namespace LibDotNetParser
     public enum StackItemType
     {
         None,
-        String,
+        Boolean,
+        Char,
+        SByte,
+        Byte,
+        Int16,
+        UInt16,
         Int32,
+        UInt32,
         Int64,
-        ldnull,
+        UInt64,
         Float32,
         Float64,
+        String,
+        ldnull,
         Object,
         Array,
         ObjectRef,
         MethodPtr,
         IntPtr,
+        UIntPtr,
         Any
     }
 }


### PR DESCRIPTION
## General Notes

The parser was using `Int32` for many types that were not actually an `Int32`, such as `Char`, `Boolean`, `Int16`, `UInt16`, `SByte`, `Byte`, `UInt32`, `IntPtr`, etc.

## Fix/Implementation 

This PR adds the other .NET types and sorts the enum a little bit based on their placement in II.23.1.16.  This PR then uses these new types as part of DotNetMethod.cs

Lastly, this PR updates the getChars method of `string` to push a stack element with type `Char` instead of `String`, which makes it easier to perform the equality check.

## Testing

All existing tests pass, although method calling may be broken for certain types at the moment.