### PR TITLE
Refactor branching/comparisons to use MathOperations

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -680,7 +680,11 @@ namespace libDotNetClr
                 else if (item.OpCodeName == "ceq")
                 {
                     if (stack.Count < 2)
-                        throw new Exception("There has to be 2 or more items on the stack for ceq instruction to work!");
+                    {
+                        clrError($"There has to be 2 or more items on the stack for {item.OpCodeName} instruction to work!", "Internal CLR error");
+                        return null;
+                    }
+
                     var a = stack.Pop();
                     var b = stack.Pop();
 
@@ -688,180 +692,61 @@ namespace libDotNetClr
                 }
                 else if (item.OpCodeName == "cgt")
                 {
-                    var numb1 = (int)stack[stack.Count - 2].value;
-                    var numb2 = (int)stack[stack.Count - 1].value;
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (numb1 > numb2)
+                    if (stack.Count < 2)
                     {
-                        //push 1
-                        stack.Add(MethodArgStack.Int32(1));
+                        clrError($"There has to be 2 or more items on the stack for {item.OpCodeName} instruction to work!", "Internal CLR error");
+                        return null;
                     }
-                    else
-                    {
-                        //push 0
-                        stack.Add(MethodArgStack.Int32(0));
-                    }
+
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.GreaterThan));
                 }
                 else if (item.OpCodeName == "clt")
                 {
-                    var numb1 = (int)stack[stack.Count - 2].value;
-                    var numb2 = (int)stack[stack.Count - 1].value;
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (numb1 < numb2)
+                    if (stack.Count < 2)
                     {
-                        //push 1
-                        stack.Add(MethodArgStack.Int32(1));
-                    }
-                    else
-                    {
-                        //push 0
-                        stack.Add(MethodArgStack.Int32(0));
-                    }
-                }
-                else if (item.OpCodeName == "blt")
-                {
-                    var numb1 = (int)stack[stack.Count - 2].value;
-                    var numb2 = (int)stack[stack.Count - 1].value;
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (numb1 < numb2)
-                    {
-                        //find the ILInstruction that is in this position
-                        int i2 = item.Position + (int)item.Operand + 1;
-                        ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
-
-                        if (inst == null)
-                            throw new Exception("Attempt to branch to null");
-                        i = inst.RelPosition - 1;
-                    }
-                    }
-                else if (item.OpCodeName == "blt.s")
-                {
-                    var numb1 = (int)stack[stack.Count - 2].value;
-                    var numb2 = (int)stack[stack.Count - 1].value;
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (numb1 < numb2)
-                    {
-                        int i2 = item.Position + (int)item.Operand + 1;
-                        ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
-
-                        if (inst == null)
-                            throw new Exception("Attempt to branch to null");
-                        i = inst.RelPosition - 1;
-                    }
-                }
-                else if (item.OpCodeName == "bge.s")
-                {
-                    var numb1 = (int)stack[stack.Count - 2].value;
-                    var numb2 = (int)stack[stack.Count - 1].value;
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (numb1 >= numb2)
-                    {
-                        //push 1
-                        stack.Add(MethodArgStack.Int32(1));
-                    }
-                    else
-                    {
-                        //push 0
-                        stack.Add(MethodArgStack.Int32(0));
-                    }
-                }
-                else if (item.OpCodeName == "beq.s")
-                {
-                    var numb1 = stack[stack.Count - 2].value;
-                    var numb2 = stack[stack.Count - 1].value;
-                    int Numb1;
-                    int Numb2;
-
-                    if (numb1 is int)
-                    {
-                        Numb1 = (int)numb1;
-                }
-                    else if (numb1 is char)
-                    {
-                        Numb1 = (int)(char)numb1;
-                    }
-                    else if (numb1 is null)
-                {
-                        Numb1 = 0;
-                    }
-                    else
-                    {
-                        clrError("Do not know where to branch, as the stack is corrupt", "Internal CLR error");
+                        clrError($"There has to be 2 or more items on the stack for {item.OpCodeName} instruction to work!", "Internal CLR error");
                         return null;
                     }
 
-                    if (numb2 is int)
-                    {
-                        Numb2 = (int)numb2;
-                }
-                    else if (numb2 is char)
-                {
-                        Numb2 = (int)(char)numb2;
-                }
-                    else if (numb2 is null)
-                {
-                        Numb2 = 0;
-                }
-                    else
-                {
-                        clrError("Do not know where to branch, as the stack is corrupt", "Internal CLR error");
-                        return null;
-                }
+                    var a = stack.Pop();
+                    var b = stack.Pop();
 
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (Numb1 == Numb2)
-                {
-                        int i2 = item.Position + (int)item.Operand + 1;
-                        ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
-
-                        if (inst == null)
-                            throw new Exception("Attempt to branch to null");
-                        i = inst.RelPosition - 1;
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.LessThan));
                 }
+                else if (item.OpCodeName == "beq" || item.OpCodeName == "beq.s")
+                {
+                    BranchWithOp(item, stack, decompiler, MathOperations.Operation.Equal, ref i);
                 }
-                else if (item.OpCodeName == "bne.un.s")
+                else if (item.OpCodeName == "bge" || item.OpCodeName == "bge.s")
                 {
-                    var numb1 = (int)stack[stack.Count - 2].value;
-                    var numb2 = (int)stack[stack.Count - 1].value;
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (numb1 != numb2)
-                {
-                        int i2 = item.Position + (int)item.Operand + 1;
-                        ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
-
-                        if (inst == null)
-                            throw new Exception("Attempt to branch to null");
-                        i = inst.RelPosition - 1;
-                    }
+                    BranchWithOp(item, stack, decompiler, MathOperations.Operation.GreaterThanEqual, ref i);
                 }
-                else if (item.OpCodeName == "ble.s")
+                // TODO: Implement bge.un and bge.un.s
+                else if (item.OpCodeName == "bgt" || item.OpCodeName == "bgt.s")
                 {
-                    var numb1 = (int)stack[stack.Count - 2].value;
-                    var numb2 = (int)stack[stack.Count - 1].value;
-                    stack.RemoveRange(stack.Count - 2, 2);
-                    if (numb1 <= numb2)
+                    BranchWithOp(item, stack, decompiler, MathOperations.Operation.GreaterThan, ref i);
+                }
+                // TODO: Implement bgt.un and bgt.un.s
+                else if (item.OpCodeName == "ble" || item.OpCodeName == "ble.s")
                 {
-                        int i2 = item.Position + (int)item.Operand + 1;
-                        ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
-
-                        if (inst == null)
-                            throw new Exception("Attempt to branch to null");
-                        i = inst.RelPosition - 1;
-                    }
+                    BranchWithOp(item, stack, decompiler, MathOperations.Operation.LessThanEqual, ref i);
+                }
+                // TODO: Implement ble.un and ble.un.s
+                else if (item.OpCodeName == "blt" || item.OpCodeName == "blt.s")
+                {
+                    BranchWithOp(item, stack, decompiler, MathOperations.Operation.LessThan, ref i);
+                }
+                // TODO: Implement blt.un and blt.un.s
+                else if (item.OpCodeName == "bne.un" || item.OpCodeName == "bne.un.s")
+                {
+                    BranchWithOp(item, stack, decompiler, MathOperations.Operation.NotEqual, ref i);
                 }
                 #endregion
                 #region Branch instructions
-                else if (item.OpCodeName == "br.s")
-                {
-                    //find the ILInstruction that is in this position
-                    int i2 = item.Position + (int)item.Operand + 1;
-                    ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
-
-                    if (inst == null)
-                        throw new Exception("Attempt to branch to null");
-                    i = inst.RelPosition - 1;
-                }
-                else if (item.OpCodeName == "br")
+                else if (item.OpCodeName == "br" || item.OpCodeName == "br.s")
                 {
                     //find the ILInstruction that is in this position
                     int i2 = item.Position + (int)item.Operand + 1;
@@ -903,7 +788,7 @@ namespace libDotNetClr
                         i = inst.RelPosition - 1;
                     }
                 }
-                else if (item.OpCodeName == "brtrue.s")
+                else if (item.OpCodeName == "brtrue.s" || item.OpCodeName == "brtrue")
                 {
                     if (stack[stack.Count - 1].value == null)
                     {
@@ -1635,7 +1520,7 @@ namespace libDotNetClr
         /// </summary>
         /// <param name="stack"></param>
         /// <param name="op"></param>
-        private void BranchSWithOp(ILInstruction instruction, CustomList<MethodArgStack> stack, IlDecompiler decompiler, MathOperations.Operation op, ref int i)
+        private void BranchWithOp(ILInstruction instruction, CustomList<MethodArgStack> stack, IlDecompiler decompiler, MathOperations.Operation op, ref int i)
         {
             var a = stack.Pop();
             var b = stack.Pop();

--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -1630,6 +1630,37 @@ namespace libDotNetClr
             return null;
         }
         /// <summary>
+        /// Branches to a target instruction (short form) if a given operation returns true.
+        /// Pops two elements off the stack as part of the comparison.
+        /// </summary>
+        /// <param name="stack"></param>
+        /// <param name="op"></param>
+        private void BranchSWithOp(ILInstruction instruction, CustomList<MethodArgStack> stack, IlDecompiler decompiler, MathOperations.Operation op, ref int i)
+        {
+            var a = stack.Pop();
+            var b = stack.Pop();
+
+            bool invert = false;
+            if (op == MathOperations.Operation.NotEqual)
+            {
+                op = MathOperations.Operation.Equal;
+                invert = true;
+            }
+
+            var result = MathOperations.Op(b, a, op);
+            if (invert) result.value = (int)result.value == 1 ? 0 : 1;
+
+            if ((int)result.value == 1)
+            {
+                int i2 = instruction.Position + (int)instruction.Operand + 1;
+                ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
+
+                if (inst == null)
+                    throw new Exception("Attempt to branch to null");
+                i = inst.RelPosition - 1;
+            }
+        }
+        /// <summary>
         /// Returns true if there is a problem
         /// </summary>
         /// <param name="stack"></param>

--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -684,7 +684,7 @@ namespace libDotNetClr
                     var a = stack.Pop();
                     var b = stack.Pop();
 
-                    stack.Add(MathOperations.Op(a, b, MathOperations.Operation.Equality));
+                    stack.Add(MathOperations.Op(b, a, MathOperations.Operation.Equal));
                 }
                 else if (item.OpCodeName == "cgt")
                 {
@@ -733,7 +733,7 @@ namespace libDotNetClr
                             throw new Exception("Attempt to branch to null");
                         i = inst.RelPosition - 1;
                     }
-                }
+                    }
                 else if (item.OpCodeName == "blt.s")
                 {
                     var numb1 = (int)stack[stack.Count - 2].value;
@@ -775,13 +775,13 @@ namespace libDotNetClr
                     if (numb1 is int)
                     {
                         Numb1 = (int)numb1;
-                    }
+                }
                     else if (numb1 is char)
                     {
                         Numb1 = (int)(char)numb1;
                     }
                     else if (numb1 is null)
-                    {
+                {
                         Numb1 = 0;
                     }
                     else
@@ -793,31 +793,31 @@ namespace libDotNetClr
                     if (numb2 is int)
                     {
                         Numb2 = (int)numb2;
-                    }
+                }
                     else if (numb2 is char)
-                    {
+                {
                         Numb2 = (int)(char)numb2;
-                    }
+                }
                     else if (numb2 is null)
-                    {
+                {
                         Numb2 = 0;
-                    }
+                }
                     else
-                    {
+                {
                         clrError("Do not know where to branch, as the stack is corrupt", "Internal CLR error");
                         return null;
-                    }
+                }
 
                     stack.RemoveRange(stack.Count - 2, 2);
                     if (Numb1 == Numb2)
-                    {
+                {
                         int i2 = item.Position + (int)item.Operand + 1;
                         ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
 
                         if (inst == null)
                             throw new Exception("Attempt to branch to null");
                         i = inst.RelPosition - 1;
-                    }
+                }
                 }
                 else if (item.OpCodeName == "bne.un.s")
                 {
@@ -825,7 +825,7 @@ namespace libDotNetClr
                     var numb2 = (int)stack[stack.Count - 1].value;
                     stack.RemoveRange(stack.Count - 2, 2);
                     if (numb1 != numb2)
-                    {
+                {
                         int i2 = item.Position + (int)item.Operand + 1;
                         ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
 
@@ -840,7 +840,7 @@ namespace libDotNetClr
                     var numb2 = (int)stack[stack.Count - 1].value;
                     stack.RemoveRange(stack.Count - 2, 2);
                     if (numb1 <= numb2)
-                    {
+                {
                         int i2 = item.Position + (int)item.Operand + 1;
                         ILInstruction inst = decompiler.GetInstructionAtOffset(i2, -1);
 

--- a/DotNetClr/CLR/MathOperations.cs
+++ b/DotNetClr/CLR/MathOperations.cs
@@ -16,7 +16,12 @@ namespace libDotNetClr
             Multiply,
             Divide,
             Remainder,
-            Equality
+            Equal,
+            NotEqual,
+            GreaterThan,
+            LessThan,
+            GreaterThanEqual,
+            LessThanEqual
         }
 
         private static MethodArgStack ConvertToInt32(MethodArgStack arg)
@@ -63,7 +68,11 @@ namespace libDotNetClr
                 case Operation.Multiply: return MethodArgStack.Float32(v1 * v2);
                 case Operation.Divide: return MethodArgStack.Float32(v1 / v2);
                 case Operation.Remainder: return MethodArgStack.Float32(v1 % v2);
-                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.Equal: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.GreaterThan: return MethodArgStack.Int32(v1 > v2 ? 1 : 0);
+                case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
+                case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
+                case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
                 default: throw new Exception("Invalid operation");
             }
         }
@@ -80,7 +89,11 @@ namespace libDotNetClr
                 case Operation.Multiply: return MethodArgStack.Float64(v1 * v2);
                 case Operation.Divide: return MethodArgStack.Float64(v1 / v2);
                 case Operation.Remainder: return MethodArgStack.Float64(v1 % v2);
-                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.Equal: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.GreaterThan: return MethodArgStack.Int32(v1 > v2 ? 1 : 0);
+                case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
+                case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
+                case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
                 default: throw new Exception("Invalid operation");
             }
         }
@@ -97,7 +110,11 @@ namespace libDotNetClr
                 case Operation.Multiply: return MethodArgStack.Int32(v1 * v2);
                 case Operation.Divide: return MethodArgStack.Int32(v1 / v2);
                 case Operation.Remainder: return MethodArgStack.Int32(v1 % v2);
-                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.Equal: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.GreaterThan: return MethodArgStack.Int32(v1 > v2 ? 1 : 0);
+                case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
+                case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
+                case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
                 default: throw new Exception("Invalid operation");
             }
         }
@@ -114,7 +131,11 @@ namespace libDotNetClr
                 case Operation.Multiply: return MethodArgStack.Int64(v1 * v2);
                 case Operation.Divide: return MethodArgStack.Int64(v1 / v2);
                 case Operation.Remainder: return MethodArgStack.Int64(v1 % v2);
-                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.Equal: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.GreaterThan: return MethodArgStack.Int32(v1 > v2 ? 1 : 0);
+                case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
+                case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
+                case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
                 default: throw new Exception("Invalid operation");
             }
         }
@@ -126,7 +147,7 @@ namespace libDotNetClr
 
             switch (op)
             {
-                case Operation.Equality: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
+                case Operation.Equal: return MethodArgStack.Int32(v1 == v2 ? 1 : 0);
                 default: throw new Exception("Invalid operation");
             }
         }


### PR DESCRIPTION
## General Notes

There was a decent amount of code duplication and some unsupported branching instructions, so this PR makes a common method for branching to avoid code duplication, and also adds different comparison operations to `MathOperations`.

## Testing

Test project still passes, although the test project does not exercise all of the opcodes that have been refactored.