### PR TITLE
Add `neg` opcode

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -583,6 +583,12 @@ namespace libDotNetClr
 
                     stack.Add(MathOperations.Op(b, a, MathOperations.Operation.Remainder));
                 }
+                else if (item.OpCodeName == "neg")
+                {
+                    var a = stack.Pop();
+
+                    stack.Add(MathOperations.Op(a, MathOperations.Operation.Negate));
+                }
                 else if (item.OpCodeName == "and")
                 {
                     var a = stack.Pop();

--- a/DotNetClr/CLR/MathOperations.cs
+++ b/DotNetClr/CLR/MathOperations.cs
@@ -21,7 +21,8 @@ namespace libDotNetClr
             GreaterThan,
             LessThan,
             GreaterThanEqual,
-            LessThanEqual
+            LessThanEqual,
+            Negate
         }
 
         private static MethodArgStack ConvertToInt32(MethodArgStack arg)
@@ -31,6 +32,18 @@ namespace libDotNetClr
                 case StackItemType.Int32: return arg;
                 case StackItemType.Char: return MethodArgStack.Int32((int)(char)arg.value);
                 default: throw new Exception("Unsupported type conversion");
+            }
+        }
+
+        public static MethodArgStack Op(MethodArgStack arg, Operation op)
+        {
+            switch (arg.type)
+            {
+                case StackItemType.Float32: return OpWithFloat32(arg, arg, op);
+                case StackItemType.Float64: return OpWithFloat64(arg, arg, op);
+                case StackItemType.Int32: return OpWithInt32(arg, arg, op);
+                case StackItemType.Int64: return OpWithInt64(arg, arg, op);
+                default: throw new NotImplementedException();
             }
         }
 
@@ -73,6 +86,7 @@ namespace libDotNetClr
                 case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
                 case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
                 case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
+                case Operation.Negate: return MethodArgStack.Float32(-v1);
                 default: throw new Exception("Invalid operation");
             }
         }
@@ -94,6 +108,7 @@ namespace libDotNetClr
                 case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
                 case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
                 case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
+                case Operation.Negate: return MethodArgStack.Float64(-v1);
                 default: throw new Exception("Invalid operation");
             }
         }
@@ -115,6 +130,7 @@ namespace libDotNetClr
                 case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
                 case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
                 case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
+                case Operation.Negate: return MethodArgStack.Int32(-v1);
                 default: throw new Exception("Invalid operation");
             }
         }
@@ -136,6 +152,7 @@ namespace libDotNetClr
                 case Operation.LessThan: return MethodArgStack.Int32(v1 < v2 ? 1 : 0);
                 case Operation.GreaterThanEqual: return MethodArgStack.Int32(v1 >= v2 ? 1 : 0);
                 case Operation.LessThanEqual: return MethodArgStack.Int32(v1 <= v2 ? 1 : 0);
+                case Operation.Negate: return MethodArgStack.Int64(-v1);
                 default: throw new Exception("Invalid operation");
             }
         }

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -586,6 +586,12 @@ namespace DotNetparserTester
             TestAssert(l1 + l2 == 8L, "long addition");
             double d1 = 5, d2 = 3.5;
             TestAssert(d1 + d2 == 8.5, "double addition");
+            short s1 = 5, s2 = 11;
+            TestAssert(s1 + s2 == (short)16, "short addition");
+            i = -100;
+            TestAssert(-i == 100, "integer negation");
+            d1 = -50.5;
+            TestAssert(-d1 == 50.5, "double negation");
 
             TestsComplete();
         }


### PR DESCRIPTION
## General Notes

This PR adds support for the `neg` opcode by adding support for single argument math operations and then calling that new method from the new `neg` opcode.

## Testing

Two new tests were added, one for integer and one for double.